### PR TITLE
[DevToolsManage.js] 常に前面表示設定の挙動修正

### DIFF
--- a/DevToolsManage.js
+++ b/DevToolsManage.js
@@ -401,7 +401,9 @@ var $gameCurrentWindow = null;
         this._devToolMinimize = false;
         this._onFocus         = false;
         this.addEventListener();
-        this.setAlwaysOnTop(true);
+        if (alwaysOnTop === 'ON') {
+            this.setAlwaysOnTop(true);
+        }        
         switch (startupDevTool) {
             case 'ON':
             case 'MINIMIZE':


### PR DESCRIPTION
プラグインマネージャーで常に前面表示をOFFにしたにもかかわらず、ウィンドウが最前面に張り付いていた現象を修正しました。
よろしければ、マージの方ご検討くださいますようお願いします。