### PR TITLE
[EventRespawn.js]ERS_MAKEの位置指定を修正

### DIFF
--- a/EventReSpawn.js
+++ b/EventReSpawn.js
@@ -129,8 +129,8 @@ function Game_PrefabEvent() {
         switch (getCommandName(command)) {
             case '生成' :
             case 'MAKE' :
-                var x = getArgNumber(args[1], 1);
-                var y = getArgNumber(args[2], 1);
+                var x = getArgNumber(args[1]);
+                var y = getArgNumber(args[2]);
                 $gameMap.spawnEvent(this.getEventIdForEventReSpawn(args[0]), x, y, extend);
                 break;
             case 'ランダム生成' :


### PR DESCRIPTION
位置指定の最低値が間違っており、(0,0)などに配置できませんね！！
例：ERS_MAKE 1 0 0
　→なんとイベントが(1,1)に置かれてしまう！

というわけで最低値を削除しました。
最低値を０にするのも一瞬考えましたが、間違った座標（負の値など）への指定が、
エラーを吐かず勝手に０に変換されるのもどうかと思い、削除で対応してます。