### PR TITLE
[EventRespawn.js]画面内判定の境界設定が間違っていたので修正

### DIFF
--- a/EventReSpawn.js
+++ b/EventReSpawn.js
@@ -266,13 +266,13 @@ function Game_PrefabEvent() {
     Game_Map.prototype.isErsCheckInnerScreen = function(x, y) {
         var ax = this.adjustX(x);
         var ay = this.adjustY(y);
-        return ax >= 0 && ay >= 0 && ax <= this.screenTileX() && ay <= this.screenTileY();
+        return ax >= 0 && ay >= 0 && ax <= this.screenTileX() - 1 && ay <= this.screenTileY() - 1;
     };
 
     Game_Map.prototype.isErsCheckOuterScreen = function(x, y) {
         var ax = this.adjustX(x);
         var ay = this.adjustY(y);
-        return ax < -1 || ay < -1 || ax > this.screenTileX() + 1 || ay > this.screenTileY() + 1;
+        return ax < -1 || ay < -1 || ax > this.screenTileX() || ay > this.screenTileY();
     };
 
     Game_Map.prototype.isErsCheckCollidedSomeone = function(type, x, y) {


### PR DESCRIPTION
ランダム生成の「画面内」判定が間違っていました。
screenTileX,Yは画面内に入るマス目の「数」で、adjustX,Yは左上を(0,0)とした座標ですので
従来の範囲指定では**一路右および下に広く**画面内判定されてしまいます。
そこで今回は単純に１引くように修正しました。

それからこれはプルリクエストには含んでいないのですが、「画面内」と「画面外」の判定の間に
一路「どちらでもない」ラインが存在するのは仕様でしょうか？
たぶんプラグイン利用者側には直感的には伝わらないと思いますので、
outerscreenの判定に等号を含めて「どちらでもないライン」を消した方が私はいいと思います！