### PR TITLE
[ParallelBgs.js]セーブ・ロード時の演奏ラインのズレを修正

### DIFF
--- a/ParallelBgs.js
+++ b/ParallelBgs.js
@@ -290,9 +290,9 @@
         this.stopAllBgs();
         var prevIndex      = this._bgsLineIndex;
         this._bgsLineIndex = 1;
-        bgsArray.forEach(function(bgs) {
-            _AudioManager_playBgs.call(this, bgs, null);
-            this._bgsLineIndex++;
+        bgsArray.forEach(function(bgs, index) {
+            this._bgsLineIndex = index;
+            this.playBgs(bgs, null);
         }, this);
         this._bgsLineIndex = prevIndex;
     };
@@ -301,7 +301,7 @@
     AudioManager.saveBgs      = function() {
         var bgsArray = [];
         this.iterateAllBgs(function() {
-            bgsArray.push(_AudioManager_saveBgs.apply(this, arguments));
+            bgsArray[this._bgsLineIndex] = _AudioManager_saveBgs.apply(this, arguments);
         }.bind(this));
         return bgsArray.length > 1 ? bgsArray : bgsArray[0];
     };


### PR DESCRIPTION
ロードした時に一部のBGSが再生されない問題を解決しました。
原因は、セーブする時の演奏ラインの番号に空きがあっても詰めて保存してしまうことでした。

例えば、マップをまたいで２つのBGSを並行演奏したいとします。
この場合は演奏ライン「１」はBGS自動演奏の対象のため、
マップを切り替えると変わってしまいますので１は使わず「２と３」で演奏することになります。
ところがこの状態でセーブしますと、前に詰めて保存されるのでロード時に「１」から順に（ズレて）再配置されてしまいます。
そして、「１」は自動演奏の対象ですのでロード直後にBGS自動演奏処理が入ります。
が、この例では自動演奏は使わないことにしていましたので「無し」になってしまいます。
つまりセーブ時には「２と３」だったBGSが「１と２」にズレて、その内「１」が「無し」で上書きされてしまいますので
片方の演奏がロード時に終了してしまうのです！！

…うおー、本当にややこしいバグですね！
というわけで演奏ライン番号を保持するように修正してみました。
よろしければマージをお願いします！