### PR TITLE
[ParallelBgs.js]戦闘終了時に一部BGSがフェードインしない問題を修正

### DIFF
--- a/ParallelBgs.js
+++ b/ParallelBgs.js
@@ -298,6 +298,27 @@
         this._bgsLineIndex = prevIndex;
     };
 
+    var _AudioManager_replayBgs = AudioManager.replayBgs;
+    AudioManager.replayBgs      = function(bgs) {
+        if (!bgs) return;
+        if (Array.isArray(bgs)) {
+            this.replayAllBgs(bgs);
+        } else {
+            _AudioManager_replayBgs.apply(this, arguments);
+        }
+    };
+
+    AudioManager.replayAllBgs = function(bgsArray) {
+        this.stopAllBgs();
+        var prevIndex      = this._bgsLineIndex;
+        this._bgsLineIndex = 1;
+        bgsArray.forEach(function(bgs, index) {
+            this._bgsLineIndex = index;
+            this.replayBgs(bgs);
+        }, this);
+        this._bgsLineIndex = prevIndex;
+    };
+
     var _AudioManager_saveBgs = AudioManager.saveBgs;
     AudioManager.saveBgs      = function() {
         var bgsArray = [];


### PR DESCRIPTION
再び問題を発見したので修正しました！
戦闘終了時は普通、マップで流れていたBGMとBGSがフェードインしながら復帰するのですが
戦闘開始前に複数のBGSを流している状態で、戦闘終了時の復帰の様子をよーく聞くと
実は一つを除いてフェードインしない（いきなりMAX音量）で流れることがわかりました。

原因はAudioManager.replayBgsが複数のBGSに対応出来ていなかったため、
replayBgs内のfadeInが一つのBGSに対してしか作動しなかったことです。
というわけで単純にreplayAllBgsを足してみました。構わなければまたマージよろしくお願いします！！