### PR TITLE
[ParallelBgs.js]タイトルへ戻る時にBGSがフェードアウトされないのを修正

### DIFF
--- a/ParallelBgs.js
+++ b/ParallelBgs.js
@@ -343,6 +343,13 @@
         }.bind(this));
     };
 
+    var _AudioManager_fadeOutBgs = AudioManager.fadeOutBgs;
+    AudioManager.fadeOutBgs      = function(time) {
+        this.iterateAllBgs(function() {
+            _AudioManager_fadeOutBgs.call(this, time);
+        }.bind(this));
+    };
+
     AudioManager.iterateAllBgs = function(callBack) {
         var prevIndex = this._bgsLineIndex;
         Object.keys(this._allBgsBuffer).forEach(function(index) {


### PR DESCRIPTION
ものすごく細かいことですので直してくださいとは言いづらかったのでまた自分で作りました。

「タイトルへ戻りますか？」「はい」「いいえ」で「はい」を選んだ時に
このプラグインで複数のBGSが流れていると一つのBGSしかフェードアウトされません。
原因はAudioManager.fadeOutBgsが複数フェードアウトに対応していなかったからです。
ですのでその対応を追加しました。