### PR TITLE
[ParallelBgs.js]BGSオプション音量の変更時に音量が変わらない問題を修正

### DIFF
--- a/ParallelBgs.js
+++ b/ParallelBgs.js
@@ -241,6 +241,21 @@
     AudioManager._bgsFading       = false;
     AudioManager._bgsFadeCounter  = 0;
 
+    var _AudioManager_bgsVolume = Object.getOwnPropertyDescriptor(AudioManager, 'bgsVolume');
+    Object.defineProperty(AudioManager, 'bgsVolume', {
+        get: function() {
+            return _AudioManager_bgsVolume.get.call(this);
+        },
+        set: function(value) {
+            _AudioManager_bgsVolume.set.call(this, value);
+            var nowBgs = this._currentBgs;
+            this.iterateAllBgs(function() {
+                if (nowBgs !== this._currentBgs) this.updateBgsParameters(this._currentBgs);
+            }.bind(this));
+        },
+        configurable: true
+    });
+
     Object.defineProperty(AudioManager, '_bgsBuffer', {
         get: function() {
             return this._allBgsBuffer[this.getBgsLineIndex()];


### PR DESCRIPTION
どうも久しぶりのPRです！
今回は、こちらのBGS並行演奏プラグインで演奏中に「オプション」を開き、
BGSの音量を変更した時にすべてのBGSの音量をきちんと変更するように修正しました！

今までは一つだけしか音量が変わらなかったのでミュートにできなかったのです(T_T)
よろしければマージをお願いします！