### PR TITLE
NameWindowが再表示できない不具合の修正

### DIFF
--- a/MessageWindowHidden.js
+++ b/MessageWindowHidden.js
@@ -6,6 +6,7 @@
 // http://opensource.org/licenses/mit-license.php
 // ----------------------------------------------------------------------------
 // Version
+// 1.3.1-SNAPSHOT 2017/07/03 古いYEP_MessageCore.jsのネーム表示ウィンドウが再表示できない不具合の修正
 // 1.3.0 2017/03/16 連動して非表示にできるピクチャを複数指定できる機能を追加
 // 1.2.1 2017/02/07 端末依存の記述を削除
 // 1.2.0 2016/01/02 メッセージウィンドウと連動して指定したピクチャの表示/非表示が自動で切り替わる機能を追加
@@ -146,7 +147,7 @@
         this.subWindows().forEach(function(subWindow) {
             this.hideSubWindow(subWindow);
         }.bind(this));
-        if (this.hasNameWindow()) this.hideSubWindow(this._nameWindow);
+        if (this.hasNameWindow() && !this.nameWindowIsSubWindow()) this.hideSubWindow(this._nameWindow);
         this.linkPictures(0);
     };
 
@@ -155,7 +156,7 @@
         this.subWindows().forEach(function(subWindow) {
             this.showSubWindow(subWindow);
         }.bind(this));
-        if (this.hasNameWindow()) this.showSubWindow(this._nameWindow);
+        if (this.hasNameWindow() && !this.nameWindowIsSubWindow()) this.showSubWindow(this._nameWindow);
         this.linkPictures(255);
     };
 
@@ -185,6 +186,15 @@
     Window_Message.prototype.hasNameWindow = function() {
         return this._nameWindow && typeof Window_NameBox !== 'undefined';
     };
+
+    /**
+     * 古いYEP_MessageCore.jsでは、ネーム表示ウィンドウはsubWindowsに含まれる
+     */
+    Window_Message.prototype.nameWindowIsSubWindow = function() {
+        return this.subWindows().filter(function(subWindow) {
+            return subWindow === this._nameWindow;
+        }, this).length > 0;
+    }
 
     Window_Message.prototype.isTriggeredHidden = function() {
         switch (param.triggerButton) {


### PR DESCRIPTION
# 概要
古いYEP_MessageCore.js のネーム表示ウィンドウが再表示できない不具合を修正します。

# 備考
最新バージョンでは問題ありませんが、古いバージョンのYEP_MessageCore.jsだとネーム表示ウィンドウがsubWindowに含まれるため、一度消した後に再表示できません。
対象プラグインをしっかり更新すべきではあるが、ツクール公式が配布しているのが（昨年11月時点で）v1.0.2とかなり古く、この不具合に引っかかってしまうものです。
特に何も考えず公式が提供しているものだからとそのまま採用している人は引っかかりがちなので、とりあえず雑に対応したPRを投げます。

ツクールユーザー登録後30日の期間限定ダウンロードで用意するより、該当プラグイン作者のHPへのリンクを貼ったほうが何倍もマシなのでは感が……。