### PR TITLE
Update DevToolsManage.js

### DIFF
--- a/DevToolsManage.js
+++ b/DevToolsManage.js
@@ -6,6 +6,7 @@
 // http://opensource.org/licenses/mit-license.php
 // ----------------------------------------------------------------------------
 // Version
+// ---   2017/11/23 Fix missing menu bar height at SceneManager.setWindowSizeForMenuBar
 // 2.3.1 2017/11/11 画面キャプチャ管理プラグインとの連携による修正
 // 2.3.0 2017/09/25 競合対策でマップとデータのリロード機能を無効にする設定を追加
 //                  最新のNW.jsかつメニューバーを表示しない場合にエラーになる問題を修正
@@ -968,6 +969,18 @@ var p = null;
         var height       = this.getMenuBarHeight();
         gameWindow.moveBy(0, -height);
         gameWindow.resizeBy(0, height);
+
+        // v 2017-11-23 add start
+        setTimeout(function() { // Fix missing menu bar height
+            var style_height = parseInt(Graphics._canvas.style.height, 10);
+            var height_diff = SceneManager._screenHeight - style_height;
+            console.log('style.height = ' + style_height + ', diff = ' + height_diff);
+            if (height_diff != 0) {
+                gameWindow.moveBy(0, -height_diff);
+                gameWindow.resizeBy(0, height_diff);
+            }
+        }, 400); // 300+
+        // ^ 2017-11-23 add end
     };
 
     SceneManager.getMenuBarHeight = function() {


### PR DESCRIPTION
テストプレイ利用時、環境によってはウィンドウのメニューバーの高さが異なるため、ゲーム画面の解像度が Community_Basic プラグインで指定した高さと異なって表示される問題に（かなり強引に）対処しました。

こちらの環境（Windows 10 Pro バージョン 1703）では1pxずれる現象が起こります。例えば Community_Basic で高さ 600px に設定していると、DevToolsManage プラグインを有効にしたときに必ず 599px で表示されるようになります。
どうやら、メニューバーの本当の高さが、ウィンドウが開いてからある程度時間が経過しないと分からないようです。

ご検討ください。