### PR TITLE
1.12.2 2018/11/04 1.11.8の修正後、一部環境でゲーム画面のFPS低下が起きていた現象を修正

### DIFF
--- a/HalfMove.js
+++ b/HalfMove.js
@@ -6,6 +6,7 @@
 // http://opensource.org/licenses/mit-license.php
 // ----------------------------------------------------------------------------
 // Version
+// 1.12.2 2018/11/04 1.11.8の修正後、一部環境でゲーム画面のFPS低下が起きていた現象を修正
 // 1.12.1 2018/10/13 すり抜けが設定が無効なイベントのページが切り替わったとき、すり抜け設定が有効になってしまう場合がある不具合を修正
 // 1.12.0 2018/08/24 移動不可の地形およびリージョンを複数指定できる機能を追加
 // 1.11.11 2018/08/23 1.11.10の修正で横一列の通路上で上に半歩上に移動できない不具合を修正
@@ -735,6 +736,7 @@
         this._eventWidth      = null;
         this._eventHeight     = null;
         this._customExpansion = false;
+        this._frontDirection  = 0;
     };
 
     Game_Player.prototype.initMembersForHalfMoveIfNeed = function() {


### PR DESCRIPTION
機能の変更や修正はありませんので、プラグインの挙動は変わりません。
実行速度の改善のみです。
ご検討下さい。

1.11.7 → 1.11.8 の時に、マップ画面の実行速度が低下していた現象を修正しました。
（1.11.7以前と同程度の速度になりました）

測定環境：
　Firefox 63：影響大（ブラウザ版）
　Chrome 65：影響なし（MV 1.6.1 開発環境・ダウンロード版）
　Chrome 70：影響なし（ブラウザ版）

Chromeは測定値に差が出ないので、ほぼ影響を受けないようです。

原因：原因は不明です。
　JavaScriptエンジンの最適化が途切れたのかもしれません。（？）
　initの時に変数の値を初期化したら直りました。
　ちなみに this._frontDirection じゃなくて例えば this._test とかで試しても同じ現象が起こります。