### PR TITLE
修正：メモ欄の設定を適切に読み込めるように修正

### DIFF
--- a/FloatingCharacter.js
+++ b/FloatingCharacter.js
@@ -6,6 +6,7 @@
 // http://opensource.org/licenses/mit-license.php
 // ----------------------------------------------------------------------------
 // Version
+// 1.4.1 2019/06/18 メモ欄の設定を適切に読み込めるように修正(ツミオ）
 // 1.4.0 2018/10/08 浮遊イベントの影を非表示にできる機能を追加
 // 1.3.0 2018/01/24 イベントを初期状態で浮遊させる機能を追加
 // 1.2.0 2018/01/07 プレイヤーの浮遊とフォロワーと連動させるかどうかを選択できる機能を追加
@@ -252,6 +253,17 @@
         return undefined;
     };
 
+    var hasMetaValue = function(object, name) {
+        var metaTagName = metaTagPrefix + name;
+        return object.meta.hasOwnProperty(metaTagName);
+    };
+
+    var hasMetaValues = function(object, names) {
+        return names.some(function(name) {
+            return hasMetaValue(object, name);
+        });
+    };
+
     var convertEscapeCharacters = function(text) {
         if (String(text) !== text) text = '';
         text = text.replace(/\\/g, '\x1b');
@@ -464,7 +476,7 @@
     Game_Event.prototype.initialize = function(mapId, eventId) {
         _Game_Event_initialize.apply(this, arguments);
         var altitude = getMetaValues(this.event(), ['高度', 'Altitude']);
-        this._noShadow = !!getMetaValues(this.event(), ['影なし', 'NoShadow']);
+        this._noShadow = !hasMetaValues(this.event(), ['影なし', 'NoShadow']);
         if (altitude !== undefined) {
             this.setInitAltitude(parseInt(altitude || 24));
         }


### PR DESCRIPTION
[ツクール公式フォーラムのスレッド](https://forum.tkool.jp/index.php?threads/%E4%BD%BF%E3%81%84%E6%96%B9%E3%81%A8%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88.59/page-8#post-17453)にて、のいぢさんがおっしゃっている部分を修正してみました。

「メモ欄で設定した値」を取得する関数(getMetaValues)が、メモ欄に何も設定されていないときにはundefinedを返すためにこの問題が起こっているようでした。

なので、メモ欄に指定の文字列が指定されているかどうかで判定をおこなうよう変更しました。

お手すきの際に、問題がないかどうかご確認いただければなと思います。
お手数ですが以上よろしくお願い致します。