### PR TITLE
1.8.2 2020/03/16 複数種類のアイテム入手時のメッセージを修正

### DIFF
--- a/Gacha.js
+++ b/Gacha.js
@@ -642,30 +642,34 @@ function Scene_Gacha() {
         }
     };
 
-    Scene_Gacha.prototype.twoOrMoreKindOfResultItem =function () {
-      return this._resultList.some((data, index, self) => self.filter(d => d !== data).length > 0);
+    Scene_Gacha.prototype.twoOrMoreKindOfResultItem = function() {
+      return this._resultList.some(function(data, index, self) {
+        return self.filter(function(d) {
+          return d !== data;
+        }).length > 0;
+      });
     };
 
-    Scene_Gacha.prototype.generateResultMessage = function () {
+    Scene_Gacha.prototype.generateResultMessage = function() {
       let resultsForMessage = {
         items: [],
         weapons: [],
         armors: []
       };
-      this._resultList.forEach(data => {
+      this._resultList.forEach(function(data) {
         let array = DataManager.isItem(data) ? resultsForMessage.items : DataManager.isWeapon(data) ? resultsForMessage.weapons : resultsForMessage.armors;
         if (!array[data.id]) {
           array[data.id] = 0;
         }
         array[data.id]++;
       });
-      resultsForMessage.items.forEach((itemNum, id) => {
+      resultsForMessage.items.forEach(function(itemNum, id) {
         $gameMessage.add(`${$dataItems[id].name} x ${itemNum}`);
       });
-      resultsForMessage.weapons.forEach((weaponNum, id) => {
+      resultsForMessage.weapons.forEach(function(weaponNum, id) {
         $gameMessage.add(`${$dataWeapons[id].name} x ${weaponNum}`);
       });
-      resultsForMessage.armors.forEach((armorNum, id) => {
+      resultsForMessage.armors.forEach(function(armorNum, id) {
         $gameMessage.add(`${$dataArmors[id].name} x ${armorNum}`)
       });
     };


### PR DESCRIPTION
# 概要
ガチャプラグインにおいて、複数の種類のアイテムを入手した際のメッセージに以下の不具合があったため、修正しました。

- 実際に入手したものと表示される名前が異なる（実際には武器防具なのに同一IDのアイテムの名前が表示される）
- 同一IDかつ複数種類の入手時に入手一覧メッセージが表示されない（ID1の武器とID1のアイテム入手時に本来は一覧メッセージを出す仕様のようだったので）