### PR TITLE
メッセージ非表示の時にメッセージ送りのボタンを押すと、表示状態に戻るようにした

### DIFF
--- a/MessageWindowHidden.js
+++ b/MessageWindowHidden.js
@@ -219,6 +219,10 @@
             } else {
                 this.showAllWindow();
             }
+        } else if (this.isHidden() && this.isTriggered()) {
+            //非表示中に決定キーなどを押すと解除する
+            this.showAllWindow();
+            Input.update();
         }
         var wait = _Window_Message_updateWait.apply(this, arguments);
         if (this.isHidden() && this.visible) {


### PR DESCRIPTION
メッセージ非表示ありのツクールゲーをプレイしていると、誤操作で非表示になって混乱する時がありました。
元々誤操作なのでボタンがわからないし、そもそもメッセージが非表示状態になってるということに気付けないことがあって。

そこで決定ボタン（やキャンセルボタン）を押せば元に戻るという処理を加えました。これなら混乱しても適当な操作で戻れるし、デメリットも特にないと思うので。

一応RPGツクールMZのマウス・キーボード・パッドでは動作確認してあります。