### PR TITLE
場所移動時間加算が 0 の場合に時間の加算処理をせずに return するように変更

### DIFF
--- a/Chronus.js
+++ b/Chronus.js
@@ -1338,6 +1338,7 @@ function Window_Chronus() {
 
     Game_Chronus.prototype.transfer = function(realTransfer) {
         if (this.isStop()) return;
+        if (!this._timeTransferAdd) return;
         if (realTransfer) {
             this.addTime(this._timeTransferAdd);
         }


### PR DESCRIPTION
短時間で場所移動を繰り返した際に時間が経過しない問題に対応しました。

時間経過の間隔が長いと場所移動のたびに _frameCount がリセットされ
時間経過することなくゲームが進行していました。

