### PR TITLE
1.7.3 2022/09/16 動画のロード完了とマップ遷移が同一フレームで起こるとエラーになる不具合を修正

### DIFF
--- a/MoviePicture.js
+++ b/MoviePicture.js
@@ -6,6 +6,7 @@
 // http://opensource.org/licenses/mit-license.php
 // ----------------------------------------------------------------------------
 // Version
+// 1.7.3 2022/09/16 動画のロード完了とマップ遷移が同一フレームで起こるとエラーになる不具合を修正
 // 1.7.2 2020/09/21 autoplayをtrueに変更
 // 1.7.1 2019/08/26 他のプラグインとの組み合わせによりエラーになる可能性のある記述を修正
 // 1.7.0 2019/06/30 動画の取得元フォルダと拡張子を変更して動画を難読化できるようにしました。
@@ -664,6 +665,7 @@
         this._pause     = null;
         this._playStart = false;
         this.bitmap     = null;
+        this._loadingState = null;
     };
 
     Sprite_Picture.prototype.isVideoPicture = function() {


### PR DESCRIPTION
# 現象
MV向けの MoviePicture.js には以下の不具合があります。

1. 動画のロード完了フレームに対象となる `Sprite_Picture` インスタンスの `.prepareVideo()` が実行され、 `._loadingState` が `prepared` になる
2. マップ遷移により、 `Scene_Map` の `.terminate()` が実行され、再生中の動画を破棄すべく、 `Spriteset_Base` の `.clearAllVideo()` が実行される

以上により、 `Sprite_Picture` インスタンスは `.bitmap === null` かつ `._loadingState === 'prepared'` の状態となり、その直後に呼ばれる `Spriteset_Base` の `.updateVideoPicture()` で条件を満たして `.startVideo()` が実行されてしまいます。

# 対応

`.startVideo` 内で `.bitmap` の null チェックを行う方法も考えましたがやや対症療法的で、 `._loadingState` が `.clearVideo` で初期化されないほうが直感に反するように思えたので、そちらを修正しています。