### PR TITLE
(MV版) PartyCommandScene.js でカスタムメニューを呼び出して戻ると戦闘終了処理が正しく行われない不具合を修正

### DIFF
--- a/PartyCommandScene.js
+++ b/PartyCommandScene.js
@@ -6,6 +6,7 @@
  http://opensource.org/licenses/mit-license.php
 ----------------------------------------------------------------------------
  Version
+ 1.0.2 2023/01/01 カスタムメニューシーンから戻ると、戦闘終了処理が正しく行われない不具合を修正
  1.0.1 2022/04/29 別シーンから戻ってきたあと、アクターコマンドに進んでからキャンセルして戻ると『戦う』が選択できなくなる場合がある問題を修正
  1.0.0 2022/04/10 初版
 ----------------------------------------------------------------------------
@@ -255,11 +256,19 @@
     var _Scene_Battle_start = Scene_Battle.prototype.start;
     Scene_Battle.prototype.start = function() {
         if (SceneManager.isPartyCommandScene()) {
+            this.resetCallAnotherSceneFlags();
             Scene_Base.prototype.start.call(this);
-            SceneManager.clearPartyCommandScene();
         } else {
             _Scene_Battle_start.apply(this);
         }
+    };
+
+    const _Scene_Battle_resetCallAnotherSceneFlags = Scene_Battle.prototype.resetCallAnotherSceneFlags;
+    Scene_Battle.prototype.resetCallAnotherSceneFlags = function () {
+        if (_Scene_Battle_resetCallAnotherSceneFlags) {
+            _Scene_Battle_resetCallAnotherSceneFlags.call(this);
+        }
+        SceneManager.clearPartyCommandScene();
     };
 
     var _Scene_Battle_startPartyCommandSelection = Scene_Battle.prototype.startPartyCommandSelection;

--- a/SceneCustomMenu.js
+++ b/SceneCustomMenu.js
@@ -6,6 +6,7 @@
  http://opensource.org/licenses/mit-license.php
 ----------------------------------------------------------------------------
  Version
+ 1.26.3 2023/01/01 PartyCommandScene.jsで戦闘シーンから遷移して戻ると戦闘終了処理が正しく行われない不具合を修正
  1.26.2 2022/12/30 戦闘テストを終了する際にエラーが出る不具合を修正
  1.26.1 2022/12/08 アクティブでないウィンドウのボタンイベントが実行されていた問題を修正
                    パッド操作を考慮しボタン名のオプションをescapeからcancelおよびmenuに変更
@@ -1016,11 +1017,19 @@
     const _Scene_Battle_start = Scene_Battle.prototype.start;
     Scene_Battle.prototype.start = function() {
         if (SceneManager.isCalledCustomMenuFromBattle()) {
-            SceneManager.resetCalledCustomMenuFromBattle();
+            this.resetCallAnotherSceneFlags();
             Scene_Base.prototype.start.call(this);
         } else {
             _Scene_Battle_start.apply(this);
         }
+    };
+
+    const _Scene_Battle_resetCallAnotherSceneFlags = Scene_Battle.prototype.resetCallAnotherSceneFlags;
+    Scene_Battle.prototype.resetCallAnotherSceneFlags = function () {
+        if (_Scene_Battle_resetCallAnotherSceneFlags) {
+            _Scene_Battle_resetCallAnotherSceneFlags.call(this);
+        }
+        SceneManager.resetCalledCustomMenuFromBattle();
     };
 
     const _Scene_Battle_terminate = Scene_Battle.prototype.terminate;


### PR DESCRIPTION
2プラグインにまたがる修正で少し複雑なコードになってしまうので、取り込んでも問題ないかどうか慎重にご判断いただければと思います。

# 不具合の概要
PartyCommandScene.js のシーン遷移フラグと、 SceneCustomMenu.js における戦闘中に呼び出したフラグがどちらか一方しかリセットされず、本来戦闘シーンの終了時に呼ばれるべき処理が飛ばされてしまっていました。
結果、戦闘終了時に `$gameParty._inBattle` がリセットされず、イベントコマンドからの戦闘を開始できない、パーティメンバーの控えが表示されないなどの不具合が生じていました。

# 修正方針
両プラグインのフラグリセット処理がどちらか片方しか呼び出されないのが問題だったので、共通のフラグリセット用メソッドを作成して、そこに処理を足す形にしています。