### PR TITLE
MakeScreenCapture (MV) ウィンドウレイヤーを持たないシーンで署名の制御文字変換ができるよう修正

### DIFF
--- a/MakeScreenCapture.js
+++ b/MakeScreenCapture.js
@@ -6,6 +6,8 @@
 // http://opensource.org/licenses/mit-license.php
 // ----------------------------------------------------------------------------
 // Version
+// 1.8.1 2023/05/26 ウィンドウレイヤーを持たないシーンで署名の制御文字変換ができるよう修正
+//                  $gameSystem, $gameVariables初期化前にはキャプチャできないよう修正
 // 1.8.0 2021/09/24 署名に制御文字\v[n]を使えるよう修正
 // 1.7.3 2018/06/28 出力パスの算出方法を変更
 // 1.7.2 2018/03/06 各種ファンクションキーにCtrlおよびAltの同時押し要否の設定を追加しました。
@@ -467,7 +469,11 @@
 
     var convertEscapeCharacters = function(text) {
         if (text == null) text = '';
-        var window = SceneManager._scene._windowLayer.children[0];
+        var window = SceneManager._scene._windowLayer
+            ? SceneManager._scene._windowLayer.children[0]
+            : !!$gameSystem && !!$gameVariables
+                ? new Window_Base(0, 0, 0, 0)   // 初期化時にupdateToneが呼ばれるため、$gameSystemの初期化も必須
+                : null;
         return window ? window.convertEscapeCharacters(text) : text;
     };
 
@@ -661,7 +667,7 @@
     };
 
     SceneManager.saveCapture = function(fileName, format) {
-        if (!this._captureBitmap) return;
+        if (!this._captureBitmap || !$gameSystem || !$gameVariables) return;
         var signature = this.getSignature();
         if (paramSignatureImage) {
             var image = ImageManager.loadPicture(paramSignatureImage, 0);


### PR DESCRIPTION
MakeScreenCaptureにおいて、Scene_Bootなどのウィンドウレイヤーを持たないシーンでキャプチャを撮影しようとするとエラーが発生するため、修正案のPRを出します。

MZ版は PluginCommonBase にコピーされた `convertEscapeCharacters` を使うようになっているため、ウィンドウレイヤーを持たないシーンでのキャプチャに不都合はありません。
SceneManager._sceneがnullの状態でキャプチャしようとすると落ちますが、これは通常、起動直後の一瞬だけですので問題にはなりにくいと思います。

# ウィンドウレイヤーを持たないシーンでの処理
ウィンドウレイヤーを持たないため、制御文字変換のためダミーのウィンドウオブジェクトを生成します。

# ゲームオブジェクト初期化前のシーン (Scene_Bootなど) での処理
`$gameSystem` や `$gameVariables` が初期化されておらず、ウィンドウオブジェクトの生成や `\V` 制御文字の変換でエラーになってしまうこと、このシーンでのスクリーンショットは流石に需要がないだろうということから、キャプチャの保存自体を無効化します。

MZ版では制御文字の変換時に `$gameVariables` が初期化されていなかった場合、制御文字そのものを消す処理を行っており、この点でMZ版と仕様がズレてしまいますが、今回はコードの複雑さを避けるためこうしています。