### PR TITLE
該当タグが存在しない場合、PartyAbilityRateが0になる問題への対処

### DIFF
--- a/PartyAbilityRate.js
+++ b/PartyAbilityRate.js
@@ -65,14 +65,14 @@
     Game_BattlerBase.prototype.partyAbilityRate = function(abilityNames) {
         return this.traitObjects().reduce((prev, traitObject) => {
             const rate = PluginManagerEx.findMetaValue(traitObject, abilityNames);
-            return !(rate == null) ? Math.max(rate, prev || 0) : prev;
+            return rate != null ? Math.max(rate, prev || 0) : prev;
         }, undefined);
     };
 
     Game_Party.prototype.partyAbilityRate = function(abilityNames) {
         return this.battleMembers().reduce((prev, actor) => {
             const rate = actor.partyAbilityRate(abilityNames);
-            return !(rate == null) ? Math.max(rate, prev || 0) : prev;
+            return rate != null ? Math.max(rate, prev || 0) : prev;
         }, undefined);
     };
 

--- a/PartyAbilityRate.js
+++ b/PartyAbilityRate.js
@@ -65,14 +65,14 @@
     Game_BattlerBase.prototype.partyAbilityRate = function(abilityNames) {
         return this.traitObjects().reduce((prev, traitObject) => {
             const rate = PluginManagerEx.findMetaValue(traitObject, abilityNames);
-            return rate !== undefined ? Math.max(rate, prev || 0) : prev;
+            return !(rate == null) ? Math.max(rate, prev || 0) : prev;
         }, undefined);
     };
 
     Game_Party.prototype.partyAbilityRate = function(abilityNames) {
         return this.battleMembers().reduce((prev, actor) => {
             const rate = actor.partyAbilityRate(abilityNames);
-            return rate !== undefined ? Math.max(rate, prev || 0) : prev;
+            return !(rate == null) ? Math.max(rate, prev || 0) : prev;
         }, undefined);
     };
 


### PR DESCRIPTION
`PluginManagerEx.findMetaValue`は該当のmetaタグが存在しない場合、undefinedではなくnullを返しております。
現状に於いてはその返却値がundefinedあればundefined、そうでなければ`返却値 || 0`をとしているため、該当のmetaタグが存在しない場合返却値null→0になります。
こちら想定した動作では恐らくない（直感的にはタグが無ければ既存のレートが適用されると考えられる）ので、確認のためにもプルリクを出させていただきました。

比較の仕方は以下を参考にしております。
https://qiita.com/_masa_u/items/4633519d6642098cd8fe