### PR TITLE
(MV) WindowBackImage 1.5.2 2024/06/01 class記法で書かれたウィンドウクラスに対応

### DIFF
--- a/WindowBackImage.js
+++ b/WindowBackImage.js
@@ -6,6 +6,7 @@
 // http://opensource.org/licenses/mit-license.php
 // ----------------------------------------------------------------------------
 // Version
+// 1.5.2 2024/06/01 class記法で書かれたウィンドウクラスに対応
 // 1.5.1 2021/01/30 バトラーステータスウィンドウが選択肢に抜けていたので追加
 // 1.5.0 2021/01/24 ウィンドウごとに個別のウィンドウスキンを指定できる機能を追加
 // 1.4.0 2020/12/28 JK_MailSystem.jsの各ウィンドウをオプション項目に追加
@@ -264,7 +265,11 @@
     'use strict';
 
     var getClassName = function(object) {
-        return object.constructor.toString().replace(/function\s+(.*)\s*\([\s\S]*/m, '$1');
+        var define = object.constructor.toString();
+        if (define.match(/^class/)) {
+            return define.replace(/class\s+(.*?)\s+[\s\S]*/m, '$1');
+        }
+        return define.replace(/function\s+(.*)\s*\([\s\S]*/m, '$1');
     };
 
     //=============================================================================


### PR DESCRIPTION
class記法で書かれたウィンドウクラス名を取得できないようだったので、取得できるように修正します。

同様の修正が [GraphicalDesignMode.js 2.10.6](https://github.com/triacontane/RPGMakerMV/commit/e392340e0dacea686f2b70625a3d99a8a96a562e) で行われていたため、今回の修正も全く同じコードとしています。