### PR TITLE
Fixed DTextPicture executes extra logic even if the NRP_EvalPluginCommand not exist.

### DIFF
--- a/DTextPicture.js
+++ b/DTextPicture.js
@@ -307,7 +307,7 @@
     // Game_Interpreter
     //  プラグインコマンド[D_TEXT]を追加定義します。
     //=============================================================================
-    if (PluginManager.parameters('NRP_EvalPluginCommand')) {
+    if ('NRP_EvalPluginCommand'.toLowerCase() in PluginManager._parameters) {
         var _Game_Interpreter_command356 = Game_Interpreter.prototype.command356;
         Game_Interpreter.prototype.command356 = function() {
             this._argClone = this._params[0].split(" ");


### PR DESCRIPTION
This PR resolves an issue where DTextPicture performs additional actions even though NRP_EvalPluginCommand is not registered in the plugin list.

I discovered this issue while troubleshooting a user who was using DTextPicture with my plugin [L10nMV.js](https://github.com/creta5164/l10nmv.js), which helps with localization, and was experiencing issues with localization.

The PluginManager in the latest core script has the following implementation in the parameters method.

https://github.com/rpgtkoolmv/corescript/blob/182e31449707ba7e406db0485c44c2a9d11e2dcd/js/rpg_managers/PluginManager.js#L32-L34

```js
PluginManager.parameters = function(name) {
    return this._parameters[name.toLowerCase()] || {};
};
```

I noticed that it returns an empty `object` instance if no plugin is present, which causes the evaluation expression in my modification to be true where it used to be false, which triggers additional logic.

This happend only for MV plugin.

This PR fixes that issue.