### PR TITLE
能力弱体化有効度が0の場合にGuardポップアップが出るように修正

### DIFF
--- a/BattleEffectPopup.js
+++ b/BattleEffectPopup.js
@@ -579,6 +579,16 @@
         return rate;
     };
 
+    const _Game_Battler_debuffRate = Game_Battler.prototype.debuffRate;
+    Game_Battler.prototype.debuffRate = function(paramId) {
+        const rate = _Game_Battler_debuffRate.apply(this, arguments);
+        console.log(rate);
+        if (rate === 0) {
+            this.result().guarded = true;
+        }
+        return rate;
+    };
+
     Game_Battler.prototype.hasAppointPopup = function() {
         return !!this._appointPopup;
     };

--- a/BattleEffectPopup.js
+++ b/BattleEffectPopup.js
@@ -582,7 +582,6 @@
     const _Game_Battler_debuffRate = Game_Battler.prototype.debuffRate;
     Game_Battler.prototype.debuffRate = function(paramId) {
         const rate = _Game_Battler_debuffRate.apply(this, arguments);
-        console.log(rate);
         if (rate === 0) {
             this.result().guarded = true;
         }


### PR DESCRIPTION
satateRateメソッドの戻りが0の場合にguardプロパティをtrueにしてGuardポップアップを出しているように見受けられます
しかし、debuffRateメソッドについては同様の処理が無く、弱体化が有効なのか有効だけど確率的に通らなかったのかがポップアップからは見て取れない仕様となっております

そこで、debuffRateメソッドにも同様の処理を追加しました